### PR TITLE
tune Secondary Vertex saving, add LHE root files

### DIFF
--- a/python/vertices_cff.py
+++ b/python/vertices_cff.py
@@ -13,7 +13,7 @@ vertexTable = cms.EDProducer("VertexTableProducer",
     svSrc = cms.InputTag("slimmedSecondaryVertices"),
     svCut = cms.string(""),
     dlenMin = cms.double(0),
-    dlenSigMin = cms.double(5),
+    dlenSigMin = cms.double(3),
     pvName = cms.string("PV"),
     svName = cms.string("SV"),
     svDoc  = cms.string("secondary vertices from IVF algorithm"),
@@ -21,7 +21,7 @@ vertexTable = cms.EDProducer("VertexTableProducer",
 
 svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
     src = cms.InputTag("vertexTable"),
-    cut = vertexTable.svCut, #this is redundant as the input tag is set to vertexTable
+    cut = cms.string(""),  #DO NOT further cut here, use vertexTable.svCut
     name = cms.string("SV"),
     singleton = cms.bool(False), # the number of entries is variable
     extension = cms.bool(True), 

--- a/python/vertices_cff.py
+++ b/python/vertices_cff.py
@@ -11,15 +11,17 @@ from  PhysicsTools.NanoAOD.common_cff import *
 vertexTable = cms.EDProducer("VertexTableProducer",
     pvSrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
     svSrc = cms.InputTag("slimmedSecondaryVertices"),
-#    cut = cms.string(""),  #not implemented
+    svCut = cms.string(""),
+    dlenMin = cms.double(0),
+    dlenSigMin = cms.double(5),
     pvName = cms.string("PV"),
     svName = cms.string("SV"),
     svDoc  = cms.string("secondary vertices from IVF algorithm"),
 )
 
 svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("slimmedSecondaryVertices"),
-    cut = cms.string(""), #we should not filter unless we filter also on the vertexTable
+    src = cms.InputTag("vertexTable"),
+    cut = vertexTable.svCut, #this is redundant as the input tag is set to vertexTable
     name = cms.string("SV"),
     singleton = cms.bool(False), # the number of entries is variable
     extension = cms.bool(True), 
@@ -31,6 +33,9 @@ svCandidateTable =  cms.EDProducer("SimpleCandidateFlatTableProducer",
         chi2   = Var("vertexNormalizedChi2()", float, doc = "reduced chi2, i.e. chi/ndof",precision=8),
     ),
 )
+svCandidateTable.variables.pt.precision=10
+svCandidateTable.variables.phi.precision=12
+
 
 #before cross linking
 vertexSequence = cms.Sequence()

--- a/test/nano_cfg.py
+++ b/test/nano_cfg.py
@@ -4,12 +4,16 @@ process = cms.Process('NANO')
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10000))
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.fileNames = [
-	'/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/1CFF7C9C-6A86-E711-A1F2-0CC47A7C35F4.root',
-	'/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/107D499F-6A86-E711-8A51-0025905B8592.root',
+#relvals:
+# '/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/1CFF7C9C-6A86-E711-A1F2-0CC47A7C35F4.root',
+# '/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/107D499F-6A86-E711-8A51-0025905B8592.root',
+
+#sample with LHE
+	'/store/mc/RunIISummer17MiniAOD/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10_ext1-v1/110000/187F7EDA-0986-E711-ABB3-02163E014C21.root'
 ]
 
 process.load("PhysicsTools.NanoAOD.nano_cff")
@@ -21,9 +25,16 @@ process.nanoPath = cms.Path(process.nanoSequenceMC)
 
 process.out = cms.OutputModule("NanoAODOutputModule",
     fileName = cms.untracked.string('nano.root'),
-    outputCommands = cms.untracked.vstring("drop *", "keep *_*Table_*_*","keep edmTriggerResults_*_*_*"),
+    outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
    #compressionLevel = cms.untracked.int32(9),
     #compressionAlgorithm = cms.untracked.string("LZMA"),
 
 )
-process.end = cms.EndPath(process.out)  
+process.out1 = cms.OutputModule("NanoAODOutputModule",
+    fileName = cms.untracked.string('lzma.root'),
+    outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
+    compressionLevel = cms.untracked.int32(9),
+    compressionAlgorithm = cms.untracked.string("LZMA"),
+
+)
+process.end = cms.EndPath(process.out+process.out1)  

--- a/test/nano_cfg.py
+++ b/test/nano_cfg.py
@@ -25,14 +25,14 @@ process.nanoPath = cms.Path(process.nanoSequenceMC)
 
 process.out = cms.OutputModule("NanoAODOutputModule",
     fileName = cms.untracked.string('nano.root'),
-    outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
+    outputCommands = cms.untracked.vstring("drop *", "keep *Table_*Table_*_*","keep edmTriggerResults_*_*_*"),
    #compressionLevel = cms.untracked.int32(9),
     #compressionAlgorithm = cms.untracked.string("LZMA"),
 
 )
 process.out1 = cms.OutputModule("NanoAODOutputModule",
     fileName = cms.untracked.string('lzma.root'),
-    outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
+    outputCommands = cms.untracked.vstring("drop *", "keep *Table_*Table_*_*","keep edmTriggerResults_*_*_*"),
     compressionLevel = cms.untracked.int32(9),
     compressionAlgorithm = cms.untracked.string("LZMA"),
 

--- a/test/step1.py
+++ b/test/step1.py
@@ -23,7 +23,7 @@ process.nanoPath = cms.Path(process.nanoSequenceMC)
 
 process.out = cms.OutputModule("PoolOutputModule",
    fileName = cms.untracked.string("step1.root"),
-   outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
+   outputCommands = cms.untracked.vstring("drop *", "keep *Table_*Table_*_*","keep edmTriggerResults_*_*_*"),
 )
 
 process.end = cms.EndPath(process.out)  

--- a/test/step1.py
+++ b/test/step1.py
@@ -8,7 +8,12 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring())
 process.source.fileNames = [
-	'/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/1CFF7C9C-6A86-E711-A1F2-0CC47A7C35F4.root',
+#relvals:
+# '/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/1CFF7C9C-6A86-E711-A1F2-0CC47A7C35F4.root',
+# '/store/relval/CMSSW_9_3_0_pre4/RelValTTbar_13/MINIAODSIM/93X_mc2017_realistic_v1-v1/00000/107D499F-6A86-E711-8A51-0025905B8592.root',
+        
+#sample with LHE
+        '/store/mc/RunIISummer17MiniAOD/TT_TuneCUETP8M2T4_13TeV-powheg-pythia8/MINIAODSIM/92X_upgrade2017_realistic_v10_ext1-v1/110000/187F7EDA-0986-E711-ABB3-02163E014C21.root'
 ]
 process.load("PhysicsTools.NanoAOD.nano_cff")
 
@@ -18,7 +23,7 @@ process.nanoPath = cms.Path(process.nanoSequenceMC)
 
 process.out = cms.OutputModule("PoolOutputModule",
    fileName = cms.untracked.string("step1.root"),
-   outputCommands = cms.untracked.vstring("drop *", "keep *_*Table_*_*","keep edmTriggerResults_*_*_*"),
+   outputCommands = cms.untracked.vstring("drop *", "keep FlatTable_*Table_*_*","keep edmTriggerResults_*_*_*"),
 )
 
 process.end = cms.EndPath(process.out)  


### PR DESCRIPTION
in addition the standard cfg now produces both zlib and lzma files

the Vertex producer now allow for selection on non-candidate stuff and produces a candidatePtr with only selected SV for the Simple table producer based on string parser