### PR TITLE
Postprocessor (experimental, not to be merged)

### DIFF
--- a/python/postprocessing/examples/keep_and_drop.txt
+++ b/python/postprocessing/examples/keep_and_drop.txt
@@ -1,0 +1,6 @@
+# this is a comment
+keep * # start with all
+drop HLT_* 
+keepmatch HLT_(Iso)?Mu\d+
+drop *_cleanmask
+dropmatch FatJet_tau[12]

--- a/python/postprocessing/examples/mhtProducer.py
+++ b/python/postprocessing/examples/mhtProducer.py
@@ -1,0 +1,59 @@
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAOD.postprocessing.framework.datamodel import Collection 
+from PhysicsTools.NanoAOD.postprocessing.framework.eventloop import Module
+
+class mhtProducer(Module):
+    def __init__(self, jetSelection, muonSelection, electronSelection):
+        self.jetSel = jetSelection
+        self.muSel = muonSelection
+        self.elSel = electronSelection
+        pass
+    def beginJob(self):
+        pass
+    def endJob(self):
+        pass
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.out.branch("MHT_pt",  "F");
+        self.out.branch("MHT_phi", "F");
+        self.out.branch("Jet_mhtCleaning", "b", lenVar="nJet")
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+        electrons = Collection(event, "Electron")
+        muons = Collection(event, "Muon")
+        jets = Collection(event, "Jet")
+        njets = len(jets)
+        mht = ROOT.TLorentzVector()
+        for lep in filter(self.muSel,muons):
+            mht += lep.p4()
+        for lep in filter(self.elSel,electrons):
+            mht += lep.p4()
+        goodjet = [ 0 for i in xrange(njets) ]
+        for i,j in enumerate(jets):
+            if not self.jetSel(j): continue
+            if j.muonIdx1 != -1 and j.muonIdx1 < njets:
+                if self.muSel(muons[j.muonIdx1]): continue # prefer the muon
+            if j.muonIdx2 != -1 and j.muonIdx2 < njets:
+                if self.muSel(muons[j.muonIdx2]): continue # prefer the muon
+            if j.electronIdx1 != -1 and j.electronIdx1 < njets:
+                if self.elSel(electrons[j.electronIdx1]): continue # prefer the electron
+            if j.electronIdx2 != -1 and j.electronIdx2 < njets:
+                if self.elSel(electrons[j.electronIdx2]): continue # prefer the electron
+            goodjet[i] = 1
+            mht += j.p4()
+        self.out.fillBranch("MHT_pt", mht.Pt())
+        self.out.fillBranch("MHT_phi", -mht.Phi()) # note the minus
+        self.out.fillBranch("Jet_mhtCleaning", goodjet)
+        return True
+
+
+# define modules using the syntax 'name = lambda : constructor' to avoid having them loaded when not needed
+
+mht = lambda : mhtProducer( lambda j : j.pt > 40, 
+                            lambda mu : mu.pt > 20 and mu.miniPFIso_all/mu.pt < 0.2,
+                            lambda el : el.pt > 20 and el.miniPFIso_all/el.pt < 0.2 ) 
+ 

--- a/python/postprocessing/framework/branchselection.py
+++ b/python/postprocessing/framework/branchselection.py
@@ -1,0 +1,33 @@
+import re
+
+class BranchSelection:
+    def __init__(self,filename):
+        comment = re.compile(r"#.*")
+        ops = []
+        for line in open(filename,'r'):
+            line = line.strip()
+            if len(line) == 0 or line[0] == '#': continue
+            line = re.sub(comment,"",line)
+            while line[-1] == "\\":
+                line = line[:-1] + " " + file.next().strip()
+                line = re.sub(comment,"",line)
+            try:
+                (op,sel) = line.split()
+                if   op == "keep": ops.append( (sel, 1) )
+                elif op == "drop": ops.append( (sel, 0) )
+                elif op == "keepmatch": ops.append( (re.compile("(:?%s)$" % sel), 1) )
+                elif op == "dropmatch": ops.append( (re.compile("(:?%s)$" % sel), 0) )
+                else:
+                    print "Error in file %s, line '%s': it's not (keep|keepmatch|drop|dropmatch) <branch_pattern>" % (filename, line)
+            except ValueError, e:
+                print "Error in file %s, line '%s': it's not (keep|keepmatch|drop|dropmatch) <branch_pattern>" % (filename, line)
+        self._ops = ops
+    def selectBranches(self,tree):
+        tree.SetBranchStatus("*",1)
+        branchNames = [ b.GetName() for b in tree.GetListOfBranches() ]
+        for bre, stat in self._ops:
+            if type(bre) == re._pattern_type:
+                for n in branchNames: 
+                    if re.match(bre, n): tree.SetBranchStatus(n, stat)
+            else:
+                tree.SetBranchStatus(bre, stat)

--- a/python/postprocessing/framework/datamodel.py
+++ b/python/postprocessing/framework/datamodel.py
@@ -1,0 +1,100 @@
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+from PhysicsTools.NanoAOD.postprocessing.framework.treeReaderArrayTools import InputTree 
+
+class Event:
+    """Class that allows seeing an entry of a PyROOT TTree as an Event"""
+    def __init__(self,tree,entry):
+        self._tree = tree
+        self._entry = entry
+        self._sync()
+    def _sync(self):
+        if self._tree.entry != self._entry:
+            if (self._tree.entry == self._entry-1):
+                self._tree._ttreereader.Next()
+            else:
+                self._tree._ttreereader.SetEntry(self._entry)
+            self._tree.entry = self._entry
+    def __getattr__(self,name):
+        if name in self.__dict__: return self.__dict__[name]
+        return self._tree.readBranch(name)
+    def __getitem__(self,attr):
+        return self.__getattr__(attr)
+    def eval(self,expr):
+        """Evaluate an expression, as TTree::Draw would do. 
+
+           This is added for convenience, but it may perform poorly and the implementation is not bulletproof,
+           so it's better to rely on reading values, collections or objects directly
+        """ 
+        if not hasattr(self._tree, '_exprs'):
+            self._tree._exprs = {}
+            # remove useless warning about EvalInstance()
+            import warnings
+            warnings.filterwarnings(action='ignore', category=RuntimeWarning, 
+                                    message='creating converter for unknown type "const char\*\*"$')
+            warnings.filterwarnings(action='ignore', category=RuntimeWarning, 
+                                    message='creating converter for unknown type "const char\*\[\]"$')
+        if expr not in self._tree._exprs:
+            formula = ROOT.TTreeFormula(expr,expr,self._tree)
+            if formula.IsInteger():
+                formula.go = formula.EvalInstance64
+            else:
+                formula.go = formula.EvalInstance
+            self._tree._exprs[expr] = formula
+            # force sync, to be safe
+            self._tree.GetEntry(self._entry)
+            self._tree.entry = self._entry
+            #self._tree._exprs[expr].SetQuickLoad(False)
+        else:
+            self._sync()
+            formula = self._tree._exprs[expr]
+        if "[" in expr: # unclear why this is needed, but otherwise for some arrays x[i] == 0 for all i > 0
+            formula.GetNdata()
+        return formula.go()
+
+class Object:
+    """Class that allows seeing a set branches plus possibly an index as an Object"""
+    def __init__(self,event,prefix,index=None):
+        self._event = event
+        self._prefix = prefix+"_"
+        self._index = index
+    def __getattr__(self,name):
+        if name in self.__dict__: return self.__dict__[name]
+        if name[:2] == "__" and name[-2:] == "__":
+            raise AttributeError
+        val = getattr(self._event,self._prefix+name)
+        if self._index != None:
+            val = val[self._index]
+        self.__dict__[name] = val ## cache
+        return val
+    def __getitem__(self,attr):
+        return self.__getattr__(attr)
+    def p4(self):
+        ret = ROOT.TLorentzVector()
+        ret.SetPtEtaPhiM(self.pt,self.eta,self.phi,self.mass)
+        return ret
+    def subObj(self,prefix):
+        return Object(self._event,self._prefix+prefix)
+    def __repr__(self):
+        return ("<%s[%s]>" % (self._prefix[:-1],self._index)) if self._index != None else ("<%s>" % self._prefix[:-1])
+    def __str__(self):
+        return self.__repr__()
+
+class Collection:
+    def __init__(self,event,prefix,lenVar=None):
+        self._event = event
+        self._prefix = prefix
+        if lenVar != None:
+            self._len = getattr(event,lenVar)
+        else:
+            self._len = getattr(event,"n"+prefix)
+        self._cache = {}
+    def __getitem__(self,index):
+        if type(index) == int and index in self._cache: return self._cache[index]
+        if index >= self._len: raise IndexError, "Invalid index %r (len is %r) at %s" % (index,self._len,self._prefix)
+        ret = Object(self._event,self._prefix,index=index)
+        if type(index) == int: self._cache[index] = ret
+        return ret
+    def __len__(self):
+        return self._len
+

--- a/python/postprocessing/framework/datamodel.py
+++ b/python/postprocessing/framework/datamodel.py
@@ -7,14 +7,7 @@ class Event:
     def __init__(self,tree,entry):
         self._tree = tree
         self._entry = entry
-        self._sync()
-    def _sync(self):
-        if self._tree.entry != self._entry:
-            if (self._tree.entry == self._entry-1):
-                self._tree._ttreereader.Next()
-            else:
-                self._tree._ttreereader.SetEntry(self._entry)
-            self._tree.entry = self._entry
+        self._tree.gotoEntry(entry)
     def __getattr__(self,name):
         if name in self.__dict__: return self.__dict__[name]
         return self._tree.readBranch(name)
@@ -46,7 +39,7 @@ class Event:
             self._tree.entry = self._entry
             #self._tree._exprs[expr].SetQuickLoad(False)
         else:
-            self._sync()
+            self._tree.gotoEntry(entry)
             formula = self._tree._exprs[expr]
         if "[" in expr: # unclear why this is needed, but otherwise for some arrays x[i] == 0 for all i > 0
             formula.GetNdata()

--- a/python/postprocessing/framework/eventloop.py
+++ b/python/postprocessing/framework/eventloop.py
@@ -1,0 +1,47 @@
+from PhysicsTools.NanoAOD.postprocessing.framework.datamodel import Event
+import sys, time
+
+class Module:
+    def __init__(self):
+        pass
+    def beginJob(self):
+        pass
+    def endJob(self):
+        pass
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    def endFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        pass
+    def analyze(self, event):
+        """process event, return True (go to next module) or False (fail, go to next event)"""
+        pass
+
+def eventLoop(modules, inputFile, outputFile, inputTree, wrappedOutputTree, maxEvents=-1, eventRange=None, progress=(10000,sys.stdout), filterOutput=True): 
+    for m in modules: 
+        m.beginFile(inputFile, outputFile, inputTree, wrappedOutputTree)
+
+    t0 = time.clock(); tlast = t0; doneEvents = 0; acceptedEvents = 0
+    entries = inputTree.entries
+
+    for i in xrange(entries) if eventRange == None else eventRange:
+        if maxEvents > 0 and i >= maxEvents-1: break
+        e = Event(inputTree,i)
+        doneEvents += 1
+        ret = True
+        for m in modules: 
+            ret = m.analyze(e) 
+            if not ret: break
+        if ret:
+            acceptedEvents += 1
+        if ret or not filterOutput: 
+            wrappedOutputTree.fill()
+        if progress:
+            if i > 0 and i % progress[0] == 0:
+                t1 = time.clock()
+                progress[1].write("Processed %8d/%8d entries (elapsed time %7.1fs, curr speed %8.3f kHz, avg speed %8.3f kHz), accepted %8d/%8d events (%5.2f%%)\n" % (
+                        i,entries, t1-t0, (progress[0]/1000.)/(max(t1-tlast,1e-9)), i/1000./(max(t1-t0,1e-9)), acceptedEvents, doneEvents, acceptedEvents/(0.01*doneEvents) ))
+                tlast = t1
+    for m in modules: 
+        m.endFile(inputFile, outputFile, inputTree, wrappedOutputTree)
+
+    return (doneEvents, acceptedEvents, time.clock() - t0)

--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -1,0 +1,80 @@
+from array import array
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+_rootBranchType2PythonArray = { 'b':'B', 'B':'b', 'i':'I', 'I':'i', 'F':'f', 'D':'d', 'l':'L', 'L':'l' }
+
+class OutputBranch:
+    def __init__(self, tree, name, rootBranchType, n=1, lenVar=None, title=None):
+        n = int(n)
+        self.buff   = array(_rootBranchType2PythonArray[rootBranchType], n*[0. if rootBranchType in 'FD' else 0])
+        self.lenVar = lenVar
+        self.n = n
+        if lenVar != None:
+            self.branch = tree.Branch(name, self.buff, "%s[%s]/%s" % (name,lenVar,rootBranchType))
+        elif n == 1:
+            self.branch = tree.Branch(name, self.buff, name+"/"+rootBranchType)
+        else:
+            self.branch = tree.Branch(name, self.buff, "%s[%d]/%s" % (name,n,rootBranchType))
+        if title: self.branch.SetTitle(title)
+    def fill(self, val):
+        if self.lenVar:
+            if len(self.buff) < len(val): # realloc
+                self.buff = array(self.buff.typecode, max(len(val),2*len(self.buff))*[0. if self.buff.typecode in 'fd' else 0])
+                self.branch.SetAddress(self.buff)
+            for i,v in enumerate(val): self.buff[i] = v
+        elif self.n == 1: 
+            self.buff[0] = val
+        else:
+            if len(val) != self.n: raise RuntimeError("Mismatch in filling branch %s of fixed length %d with %d values (%s)" % (self.Branch.GetName(),self.n,len(val),val))
+            for i,v in enumerate(val): self.buff[i] = v
+
+class OutputTree:
+    def __init__(self, tfile, ttree):
+        self._file = tfile
+        self._tree = ttree
+        self._branches = {} 
+    def branch(self, name, rootBranchType, n=1, lenVar=None, title=None):
+        if (lenVar != None) and (lenVar not in self._branches) and (not self._tree.GetBranch(lenVar)):
+            self._branches[lenVar] = OutputBranch(self._tree, lenVar, "i")
+        self._branches[name] = OutputBranch(self._tree, name, rootBranchType, n=n, lenVar=lenVar, title=title)
+        return self._branches[name]
+    def fillBranch(self, name, val):
+        br = self._branches[name]
+        if br.lenVar and (br.lenVar in self._branches):
+            self._branches[br.lenVar].buff[0] = len(val)
+        br.fill(val)
+    def tree(self):
+        return self._tree
+    def fill(self):
+        self._tree.Fill()
+    def write(self):
+        self._file.cd()
+        self._tree.Write()
+
+class FullOutput(OutputTree):
+    def __init__(self, inputFile, inputTree, outputFile, branchSelection = [], fullClone = False):
+        outputFile.cd()
+        inputTree.SetBranchStatus("*",1)
+        branchList  = inputTree.GetListOfBranches()
+        branchNames = [ branchList.At(i).GetName() for i in xrange(branchList.GetSize()) ]
+        for bre, stat in branchSelection:
+            if type(bre) == re._pattern_type:
+                for n in branchNames: 
+                    if re.match(bre, n): inputTree.SetBranchStatus(n, stat)
+            else:
+                inputTree.SetBranchStatus(n, stat)
+        outputTree = inputTree.CopyTree('1') if fullClone else inputTree.CloneTree(0)
+        OutputTree.__init__(self, outputFile, outputTree)
+        self._inputTree = inputTree
+        # FIXME process the other TTrees
+    def fill(self):
+        self._inputTree.GetEntry(self._inputTree.entry)
+        self._tree.Fill()
+
+class FriendOutput(OutputTree):
+    def __init__(self, inputFile, inputTree, outputFile, treeName="Friends"):
+        outputFile.cd()
+        outputTree = ROOT.TTree(treeName,"Friend tree for "+inputTree.GetName())
+        OutputTree.__init__(self, outputFile, outputTree)
+

--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -53,17 +53,10 @@ class OutputTree:
         self._tree.Write()
 
 class FullOutput(OutputTree):
-    def __init__(self, inputFile, inputTree, outputFile, branchSelection = [], fullClone = False, provenance=False):
+    def __init__(self, inputFile, inputTree, outputFile, branchSelection = None, fullClone = False, provenance = False):
         outputFile.cd()
-        inputTree.SetBranchStatus("*",1)
-        branchList  = inputTree.GetListOfBranches()
-        branchNames = [ branchList.At(i).GetName() for i in xrange(branchList.GetSize()) ]
-        for bre, stat in branchSelection:
-            if type(bre) == re._pattern_type:
-                for n in branchNames: 
-                    if re.match(bre, n): inputTree.SetBranchStatus(n, stat)
-            else:
-                inputTree.SetBranchStatus(n, stat)
+        if branchSelection: 
+            branchSelection.selectBranches(inputTree)
         outputTree = inputTree.CopyTree('1') if fullClone else inputTree.CloneTree(0)
         OutputTree.__init__(self, outputFile, outputTree)
         self._inputTree = inputTree

--- a/python/postprocessing/framework/output.py
+++ b/python/postprocessing/framework/output.py
@@ -69,7 +69,7 @@ class FullOutput(OutputTree):
         self._inputTree = inputTree
         # FIXME process the other TTrees
     def fill(self):
-        self._inputTree.GetEntry(self._inputTree.entry)
+        self._inputTree.readAllBranches()
         self._tree.Fill()
 
 class FriendOutput(OutputTree):

--- a/python/postprocessing/framework/preskimming.py
+++ b/python/postprocessing/framework/preskimming.py
@@ -1,0 +1,57 @@
+import json
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+class JSONFileFilter:
+    def __init__(self,fname):
+        self.keep = {}
+        for _run,lumis in json.load(open(fname, 'r')).iteritems():
+            run = long(_run)
+            if run not in self.keep: self.keep[run] = []
+            self.keep[run] += lumis
+    def filterRunLumi(self,run,lumi):
+        try:
+            for (l1,l2) in self.keep[run]:
+                if l1 <= lumi and lumi <= l2: return True
+            return False
+        except KeyError:
+            return False
+    def filterRunOnly(self,run):
+        return (run in self.keep)
+    def runCut(self):
+        return "%d <= run && run <= %s" % (min(self.keep.iterkeys()), max(self.keep.iterkeys()))
+    def filterEList(self, tree, elist):
+        #FIXME this can be optimized for sure
+        tree.SetBranchStatus("*", 0)
+        tree.SetBranchStatus('run',1)
+        tree.SetBranchStatus('luminosityBlock',1)
+        filteredList = ROOT.TEntryList('filteredList','filteredList')
+        if elist:
+            for i in xrange(elist.GetN()):
+                entry = elist.GetEntry() if i == 0 else elist.Next()
+                tree.GetEntry(entry)
+                if self.filterRunLumi(tree.run, tree.luminosityBlock):
+                    filteredList.Enter(entry)
+        else:
+            for entry in xrange(tree.GetEntries()):
+                tree.GetEntry(entry)
+                if self.filterRunLumi(tree.run, tree.luminosityBlock):
+                    filteredList.Enter(entry)
+        tree.SetBranchStatus("*", 1)
+        return filteredList
+                
+
+def preSkim(tree, jsonFile = None, cutstring = None):
+    if jsonFile == None and cutstring == None: 
+        return None
+    cut = None
+    if jsonFile != None:
+        jsonFilter = JSONFileFilter(jsonFile)
+        cut = jsonFilter.runCut()
+    if cutstring != None: 
+        cut = "(%s) && (%s)" % (cutstring, cut) if cut else cutstring
+    tree.Draw('>>elist',cut,"entrylist")
+    elist = ROOT.gDirectory.Get('elist')
+    if jsonFile:
+        elist = jsonFilter.filterEList(elist)
+    return elist

--- a/python/postprocessing/framework/treeReaderArrayTools.py
+++ b/python/postprocessing/framework/treeReaderArrayTools.py
@@ -1,0 +1,91 @@
+import types
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+def InputTree(tree,entrylist=None):
+    """add to the PyROOT wrapper of a TTree a TTreeReader and methods readBranch, arrayReader, valueReader""" 
+    if hasattr(tree, '_ttreereader'): return tree # don't initialize twice
+    tree.entry = -1
+    tree._ttreereader = ROOT.TTreeReader(tree,entrylist)
+    #if entrylist: print "Created with an entrylist with %d events" % entrylist.GetN()
+    tree._ttreereader.SetEntry(0)
+    tree._ttrvs = {}
+    tree._ttras = {}
+    tree._leafTypes = {}
+    tree._ttreereaderversion = 1
+    tree.arrayReader = types.MethodType(getArrayReader, tree)
+    tree.valueReader = types.MethodType(getValueReader, tree)
+    tree.readBranch = types.MethodType(readBranch, tree)
+    tree.entries = tree._ttreereader.GetEntries(False)
+    return tree
+
+def getArrayReader(tree, branchName, isClean=False):
+    """Make a reader for branch branchName containing a variable-length value array. 
+       If you are sure nobody has yet read from the tree, you can set isClean to True and save some overhead."""
+    if branchName not in tree._ttras:
+       if not tree.GetBranch(branchName): raise RuntimeError, "Can't find branch '%s'" % branchName
+       leaf = tree.GetBranch(branchName).GetLeaf(branchName)
+       if not leaf.GetLen() == 0: raise RuntimeError, "Branch %s is not a variable-length value array" % branchName
+       typ = leaf.GetTypeName()
+       tree._ttras[branchName] = _makeArrayReader(tree, typ, branchName, remakeAllFirst=not(isClean))
+    return tree._ttras[branchName]
+
+def getValueReader(tree, branchName, isClean=False):
+    """Make a reader for branch branchName containing a single value. 
+       If you are sure nobody has yet read from the tree, you can set isClean to True and save some overhead."""
+    if branchName not in tree._ttrvs:
+       if not tree.GetBranch(branchName): raise RuntimeError, "Can't find branch '%s'" % branchName
+       leaf = tree.GetBranch(branchName).GetLeaf(branchName)
+       if not leaf.GetLen() == 1: raise RuntimeError, "Branch %s is not a value" % branchName
+       typ = leaf.GetTypeName()
+       tree._ttrvs[branchName] = _makeValueReader(tree, typ, branchName, remakeAllFirst=not(isClean))
+    return tree._ttrvs[branchName]
+
+
+def readBranch(tree, branchName):
+    """Return the branch value if the branch is a value, and a TreeReaderArray if the branch is an array"""
+    if branchName in tree._ttras: 
+        return tree._ttras[branchName]
+    elif branchName in tree._ttrvs: 
+        return tree._ttrvs[branchName].Get()[0]
+    else:
+        branch = tree.GetBranch(branchName)
+        if not branch: raise RuntimeError, "Unknown branch %s" % branchName
+        leaf = branch.GetLeaf(branchName)
+        typ = leaf.GetTypeName()
+        if leaf.GetLen() == 1 and not bool(leaf.GetLeafCount()): 
+            return _makeValueReader(tree, typ, branchName).Get()[0]
+        else:
+            return _makeArrayReader(tree, typ, branchName)
+        
+
+####### PRIVATE IMPLEMENTATION PART #######
+
+def _makeArrayReader(tree, typ, nam, remakeAllFirst=True):
+    if remakeAllFirst: _remakeAllReaders(tree) 
+    ttra = ROOT.TTreeReaderArray(typ)(tree._ttreereader, nam)
+    tree._leafTypes[nam] = typ
+    tree._ttras[nam] = ttra;
+    tree._ttreereader.SetEntry(tree.entry)
+    return tree._ttras[nam]
+
+def _makeValueReader(tree, typ, nam, remakeAllFirst=True):
+    if remakeAllFirst: _remakeAllReaders(tree) 
+    ttrv = ROOT.TTreeReaderValue(typ)(tree._ttreereader, nam)
+    tree._leafTypes[nam] = typ
+    tree._ttrvs[nam] = ttrv
+    tree._ttreereader.SetEntry(tree.entry)
+    return tree._ttrvs[nam]
+
+def _remakeAllReaders(tree):
+    _ttreereader = ROOT.TTreeReader(tree)
+    _ttrvs = {}
+    for k in tree._ttrvs.iterkeys():
+        _ttrvs[k] = ROOT.TTreeReaderValue(tree._leafTypes[k])(_ttreereader,k)
+    _ttras = {}
+    for k in tree._ttras.iterkeys():
+        _ttras[k] = ROOT.TTreeReaderArray(tree._leafTypes[k])(_ttreereader,k)
+    tree._ttrvs = _ttrvs
+    tree._ttras = _ttras
+    tree._ttreereader = _ttreereader
+    tree._ttreereaderversion += 1

--- a/python/postprocessing/run.py
+++ b/python/postprocessing/run.py
@@ -3,6 +3,7 @@ import os, sys
 import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 from importlib import import_module
+from PhysicsTools.NanoAOD.postprocessing.framework.branchselection import BranchSelection 
 from PhysicsTools.NanoAOD.postprocessing.framework.datamodel import InputTree 
 from PhysicsTools.NanoAOD.postprocessing.framework.eventloop import eventLoop 
 from PhysicsTools.NanoAOD.postprocessing.framework.output import FriendOutput, FullOutput 
@@ -13,20 +14,33 @@ if __name__ == "__main__":
     parser = OptionParser(usage="%prog [options] outputDir inputFiles")
     parser.add_option("-s", "--postfix",dest="postfix", type="string", default=None, help="Postfix which will be appended to the file name (default: _Friend for friends, _Skim for skims)")
     parser.add_option("-J", "--json",  dest="json", type="string", default=None, help="Select events using this JSON file")
-    parser.add_option("-c", "--cut",  dest="cut", type="string", default=None, help="Cut selection")
+    parser.add_option("-c", "--cut",  dest="cut", type="string", default=None, help="Cut string")
+    parser.add_option("-b", "--branch-selection",  dest="branchsel", type="string", default=None, help="Branch selection")
     parser.add_option("--friend",  dest="friend", action="store_true", default=False, help="Produce friend trees in output (current default is to produce full trees)")
     parser.add_option("--full",  dest="friend", action="store_false",  default=False, help="Produce full trees in output (this is the current default)")
     parser.add_option("--noout",  dest="noOut", action="store_true",  default=False, help="Do not produce output, just run modules")
     parser.add_option("--justcount",   dest="justcount", default=False, action="store_true",  help="Just report the number of selected events") 
     parser.add_option("-I", "--import", dest="imports",  type="string", default=[], action="append", nargs=2, help="Import modules (python package, comma-separated list of ");
+    parser.add_option("-z", "--compression",  dest="compression", type="string", default=("LZMA:9"), help="Compression: none, or (algo):(level) ")
 
     (options, args) = parser.parse_args()
 
     if options.friend:
         if options.cut or options.json: raise RuntimeError("Can't apply JSON or cut selection when producing friends")
+
     if not options.noOut:
         outdir = args[0]; args = args[1:]
         outpostfix = options.postfix if options.postfix != None else ("_Friend" if options.friend else "_Skim")
+        branchsel = BranchSelection(options.branchsel) if options.branchsel else None
+        if options.compression != "none":
+            ROOT.gInterpreter.ProcessLine("#include <Compression.h>")
+            (algo, level) = options.compression.split(":")
+            compressionLevel = int(level)
+            if   algo == "LZMA": compressionAlgo  = ROOT.ROOT.kLZMA
+            elif algo == "ZLIB": compressionAlgo  = ROOT.ROOT.kZLIB
+            else: raise RuntimeError("Unsupported compression %s" % algo)
+        else:
+            compressionLevel = 0 
 
     if not options.noOut:
         print "Will write selected trees to "+outdir
@@ -74,16 +88,15 @@ if __name__ == "__main__":
 
         # prepare output file
         outFileName = os.path.join(outdir, os.path.basename(fname).replace(".root",outpostfix+".root"))
-        outFile = ROOT.TFile.Open(outFileName, "RECREATE")
-        #FIXME set compression
+        outFile = ROOT.TFile.Open(outFileName, "RECREATE", "", compressionLevel)
+        if compressionLevel: outFile.SetCompressionAlgorithm(compressionAlgo)
 
         # prepare output tree
         if options.friend:
             outTree = FriendOutput(inFile, inTree, outFile)
         else:
-            # FIXME branch selection
-            outTree = FullOutput(inFile, inTree, outFile, fullClone = fullClone)
-            # FIXME process the other TTrees
+            # FIXME process the other TTrees if there is a JSON
+            outTree = FullOutput(inFile, inTree, outFile, branchSelection = branchsel, fullClone = fullClone)
 
         # process events, if needed
         if not fullClone:

--- a/python/postprocessing/run.py
+++ b/python/postprocessing/run.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+import os, sys
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+from importlib import import_module
+from PhysicsTools.NanoAOD.postprocessing.framework.datamodel import InputTree 
+from PhysicsTools.NanoAOD.postprocessing.framework.eventloop import eventLoop 
+from PhysicsTools.NanoAOD.postprocessing.framework.output import FriendOutput, FullOutput 
+from PhysicsTools.NanoAOD.postprocessing.framework.preskimming import preSkim
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+    parser = OptionParser(usage="%prog [options] outputDir inputFiles")
+    parser.add_option("-s", "--postfix",dest="postfix", type="string", default=None, help="Postfix which will be appended to the file name (default: _Friend for friends, _Skim for skims)")
+    parser.add_option("-J", "--json",  dest="json", type="string", default=None, help="Select events using this JSON file")
+    parser.add_option("-c", "--cut",  dest="cut", type="string", default=None, help="Cut selection")
+    parser.add_option("--friend",  dest="friend", action="store_true", default=False, help="Produce friend trees in output (current default is to produce full trees)")
+    parser.add_option("--full",  dest="friend", action="store_false",  default=False, help="Produce full trees in output (this is the current default)")
+    parser.add_option("--noout",  dest="noOut", action="store_true",  default=False, help="Do not produce output, just run modules")
+    parser.add_option("--justcount",   dest="justcount", default=False, action="store_true",  help="Just report the number of selected events") 
+    parser.add_option("-I", "--import", dest="imports",  type="string", default=[], action="append", nargs=2, help="Import modules (python package, comma-separated list of ");
+
+    (options, args) = parser.parse_args()
+
+    if options.friend:
+        if options.cut or options.json: raise RuntimeError("Can't apply JSON or cut selection when producing friends")
+    if not options.noOut:
+        outdir = args[0]; args = args[1:]
+        outpostfix = options.postfix if options.postfix != None else ("_Friend" if options.friend else "_Skim")
+
+    if not options.noOut:
+        print "Will write selected trees to "+outdir
+        if not options.justcount:
+            if not os.path.exists(outdir):
+                os.system("mkdir -p "+outdir)
+
+    modules = []
+    for mod, names in options.imports: 
+        import_module(mod)
+        obj = sys.modules[mod]
+        selnames = names.split(",")
+        for name in dir(obj):
+            if name[0] == "_": continue
+            if name in selnames:
+                print "Loading %s from %s " % (name, mod)
+                modules.append(getattr(obj,name)())
+    if options.noOut:
+        if len(modules) == 0: 
+            raise RuntimeError("Running with --noout and no modules does nothing!")
+
+    for m in modules: m.beginJob()
+
+    fullClone = (len(modules) == 0)
+
+    for fname in args:
+        # open input file
+        inFile = ROOT.TFile.Open(fname)
+
+        #get input tree
+        inTree = inFile.Get("Events")
+
+        # pre-skimming
+        elist = preSkim(inTree, options.json, options.cut)
+        if options.justcount:
+            print 'Would select %d entries from %s'%(elist.GetN() if elist else inTree.GetEntries(), fname)
+            continue
+
+        if fullClone:
+            # no need of a reader (no event loop), but set up the elist if available
+            if elist: inTree.SetEntryList(elist)
+        else:
+            # initialize reader
+            inTree = InputTree(inTree, elist) 
+
+        # prepare output file
+        outFileName = os.path.join(outdir, os.path.basename(fname).replace(".root",outpostfix+".root"))
+        outFile = ROOT.TFile.Open(outFileName, "RECREATE")
+        #FIXME set compression
+
+        # prepare output tree
+        if options.friend:
+            outTree = FriendOutput(inFile, inTree, outFile)
+        else:
+            # FIXME branch selection
+            outTree = FullOutput(inFile, inTree, outFile, fullClone = fullClone)
+            # FIXME process the other TTrees
+
+        # process events, if needed
+        if not fullClone:
+            (nall, npass, time) = eventLoop(modules, inFile, outFile, inTree, outTree)
+            print 'Processed %d entries from %s, selected %d entries' % (nall, fname, npass)
+        else:
+            print 'Selected %d entries from %s' % (outTree.tree().GetEntries(), fname)
+
+        # now write the output
+        outTree.write()
+        outFile.Close()
+        print "Done %s" % outFileName
+
+    for m in modules: m.endJob()

--- a/python/postprocessing/tools.py
+++ b/python/postprocessing/tools.py
@@ -1,0 +1,31 @@
+from math import hypot
+
+#### ========= UTILITIES =======================
+def deltaPhi(phi1,phi2):
+    ## Catch if being called with two objects
+    if type(phi1) != float and type(phi1) != int:
+        phi1 = phi1.phi
+    if type(phi2) != float and type(phi2) != int:
+        phi2 = phi2.phi
+    ## Otherwise
+    dphi = (phi1-phi2)
+    while dphi >  pi: dphi -= 2*pi
+    while dphi < -pi: dphi += 2*pi
+    return dphi
+
+def deltaR(eta1,phi1,eta2=None,phi2=None):
+    ## catch if called with objects
+    if eta2 == None:
+        return deltaR(eta1.eta,eta1.phi,phi1.eta,phi1.phi)
+    ## otherwise
+    return hypot(eta1-eta2, deltaPhi(phi1,phi2))
+
+def closest(obj,collection,presel=lambda x,y: True):
+    ret = None; drMin = 999
+    for x in collection:
+        if not presel(obj,x): continue
+        dr = deltaR(obj,x)
+        if dr < drMin: 
+            ret = x; drMin = dr
+    return (ret,drMin)
+


### PR DESCRIPTION
Post-processing of files
*  `python run.py outputdir intputtree.root  --cut "nMuon > 0"  `
     this makes a skim; can use `--branch-selection` to choose output branches (and it should not affect what branches you can use in the cut string)
     still to implement: read cut from text file, apply JSON to run & lumi trees
     still to test: JSON
* `python run.py outputdir linputtree.root -I PhysicsTools.NanoAOD.postprocessing.examples.mhtProducer  mht --friend`
   this makes a friend tree running the `mht` module in that python file
* `python run.py outputdir linputtree.root -I PhysicsTools.NanoAOD.postprocessing.examples.mhtProducer  mht [ --full ]`
    this makes a skim - if the modules return false on some entries - and also add branches; you can also add `--cut` to specify a preselection cut run before the modules. 
    one can use `--branch-selection`, but currently branches turned off may not be available in the modules (to be tested)
